### PR TITLE
Add missing active attribute to IdentityInfo

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -614,6 +614,7 @@ export type IdentityInfo = {
   };
   user_type: string;
   language: string;
+  active: boolean;  
 };
 
 export type UserInfo = {


### PR DESCRIPTION
As per documentation there is active property also for identity:
active	Boolean specifying whether the queried user is active.

https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_using_openid.htm&type=5